### PR TITLE
Fix: Bug for Mini-Drawer causing unnecessary whitespace

### DIFF
--- a/client/src/features/mini-drawer/MiniDrawer.tsx
+++ b/client/src/features/mini-drawer/MiniDrawer.tsx
@@ -262,7 +262,7 @@ export default function MiniDrawer() {
         </DrawerHeader>
         <Typography>Testing</Typography>
       </Drawer>
-      <main style={{ marginLeft: 200, padding: 20 }}>
+      <main>
         {selectedPage === "ClusterUI" && <ClusterViewContainer />}
         {selectedPage === "Logs" && <LogPage />}
         {selectedPage === "Settings" && <Settings />}


### PR DESCRIPTION
Fixed issue causing whitespace to cover part of the page when mini-drawer is accessed