### PR TITLE
Fix: Log Page Positioning Bug

### DIFF
--- a/client/src/features/log-page/LogPage.tsx
+++ b/client/src/features/log-page/LogPage.tsx
@@ -62,18 +62,22 @@ export default function LogPage() {
   }
   console.log(store)
   return (
-    <div>
+    <div style={{ position: "absolute", left: "250px", top: "100px" }}>
       {/* <Box sx={{marginLeft: '8px', marginTop: '96px', overflowY: 'scroll', border: 1, borderColor: "black", maxWidth: '1450px',}}> */}
       <h1
         style={{
+          textAlign: "center",
           marginLeft: "32px",
           marginBottom: "16px",
+          minWidth: "700px",
         }}
       >
         Logs
       </h1>
       <Button
         style={{
+          display: "flex",
+          left: "290px",
           marginLeft: "32px",
           marginBottom: "16px",
         }}


### PR DESCRIPTION
Fix: Added absolute Log Page container positioning to prevent the moving of container and button when logs are added

## Description

Log Page and Logs are now positioned at top center of page and set to absolute as to prevent container movement and mispositioning when logs are added

## Reproduction steps

Inline styling to fix bugs and set absolute positioning by added on lines 65, 69, and 72, 79, and 80

## Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I've followed the [Contributing guidelines](https://github.com/oslabs-beta/.github/blob/main/docs/CONTRIBUTING.md)
- [x] I've titled my PR according to the [Conventional Commits spec](https://conventionalcommits.org)
- [ ] I've added tests that fail without this PR but pass with it
- [x] I've linted, tested, and commented my code
- [ ] I've updated documentation (if appropriate)
